### PR TITLE
Remove unused HDWalletProvider boilerplate

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,8 +1,3 @@
-const HDWalletProvider = require('@truffle/hdwallet-provider');
-
-const fs = require('fs');
-const mnemonic = fs.readFileSync(".secret").toString().trim();
-
 module.exports = {
 
   networks: {


### PR DESCRIPTION
These imports/variables were totally unused and causing `truffle version` to explode.

(Should we also remove the `@truffle/hdwallet-provider` devDep?)